### PR TITLE
Update 2026

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Run offline tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The source code is available in the file ``meteosource.js`` and requires the dat
 
 ```HTML
 <script src="https://www.meteosource.com/js/libs/meteosource.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/luxon@2.4.0/build/global/luxon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
 
 <script>document.write(meteosource.version)</script> <!-- returns 1.0.1 -->
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ let airQuality = await m.getAirQuality({
     lat: null,  // You can specify lat+lon instead of placeId
     lon: null,
     tz: 'UTC',  // Defaults to 'UTC', regardless of the point location
-    lang: 'en',
 })
 
 console.log(airQuality.data[0].air_quality)  // air quality index for the first hour

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The source code is available in the file ``meteosource.js`` and requires the dat
 <script src="https://www.meteosource.com/js/libs/meteosource.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
 
-<script>document.write(meteosource.version)</script> <!-- returns 1.0.1 -->
+<script>document.write(meteosource.version)</script> <!-- returns 1.1.0 -->
 ```
 
 ### Installation: NPM (Node.js)
@@ -25,7 +25,7 @@ $ npm install meteosource
 $ node
 > meteosource = require("meteosource")
 > meteosource.version
-'1.0.1'
+'1.1.0'
 ```
 
 
@@ -92,6 +92,42 @@ let timeMachine = await m.getTimeMachine({
 Note that the historical weather data are always retrieved for full UTC days. If you specify a different timezone, the datetimes get converted, but they will cover the full UTC, not the local day.
 
 If you pass an array of dates to the `date` parameter, the days will be inserted into the inner structures in the order they are being iterated over. This affects time indexing by integer (see below). An API request is made for each day, even when you specify a date range.
+
+### Air quality
+To get the hourly air quality forecast (pollutant concentrations and air quality index), use the `getAirQuality()` method. You have to specify either the coordinates of the place (`lat` + `lon`) or the `placeId`:
+
+```javascript
+let airQuality = await m.getAirQuality({
+    placeId: 'london',  // ID of the place you want the air quality for
+    lat: null,  // You can specify lat+lon instead of placeId
+    lon: null,
+    tz: 'UTC',  // Defaults to 'UTC', regardless of the point location
+    lang: 'en',
+})
+
+console.log(airQuality.data[0].air_quality)  // air quality index for the first hour
+console.log(airQuality.getData("2026-07-28T02:00:00Z"))  // data for a specific hour
+```
+
+The `date` of each item in `data` is converted to `luxon.DateTime`, and the object supports the same `getData()` time indexing as the other endpoints (see below).
+
+### Finding places
+To search for places by name, use the `findPlaces()` method, or `findPlacesPrefix()` for a prefix search (useful for autocomplete forms). Both return an array of places:
+
+```javascript
+let places = await m.findPlaces({text: 'london', lang: 'en'})
+let placesByPrefix = await m.findPlacesPrefix({text: 'lond'})
+
+console.log(places[0].toString())  // <Place London (london), United Kingdom>
+console.log(places[0].place_id)  // 'london'
+```
+
+To get the nearest named place for given GPS coordinates, use the `getNearestPlace()` method:
+
+```javascript
+let place = await m.getNearestPlace({lat: 51.50853, lon: -0.1257})
+console.log(place.place_id)  // 'london'
+```
 
 ## Working with the weather data
 All of the data objects have overloaded `toString()` methods, so you can use them get useful information about the objects:

--- a/meteosource.js
+++ b/meteosource.js
@@ -426,7 +426,7 @@
     }
 
     exports.Meteosource = Meteosource
-    exports.version = "1.0.1"
+    exports.version = "1.1.0"
     exports.tiersAvailable = tiersAvailable
 
     return exports

--- a/meteosource.js
+++ b/meteosource.js
@@ -147,13 +147,12 @@
             res.toString = function() {
                 return "<Forecast for lat: " + res.lat + ", lon: " + res.lon + ">"
             }
-            if(res.hourly !== null) {
+            if(res.hourly !== null && res.hourly !== undefined) {
                 res.hourly.toString = function() {
                     return "<Hourly data with " + res.hourly.data.length + " timesteps from " +
                         res.hourly.data[0].date.toISO().substr(0, 19) + " to " + res.hourly.data[res.hourly.data.length-1].date.toISO().substr(0, 19)
                 }
                 let hourStr2hourData = {}
-                let luxon = this.#luxon
                 res.hourly.data.forEach(hourData => {
                     hourStr2hourData[hourData.date] = hourData
                     hourData.date = this.#convertCheckDateTime(hourData.date, true).setZone(usedTimezone)
@@ -163,29 +162,27 @@
                     return hourStr2hourData[hourDate.setZone("UTC").startOf("hour").toISO().substr(0, 19)]
                 }
             }
-            if(res.daily !== null) {
+            if(res.daily !== null && res.daily !== undefined) {
                 res.daily.toString = function() {
                     return "<Daily data with " + res.daily.data.length + " steps from " +
                         res.daily.data[0].day.toISO().substr(0, 10) +
                         " to " + res.daily.data[res.daily.data.length-1].day.toISO().substr(0, 10)
                 }
                 let dayStr2dayData = {}
-                let luxon = this.#luxon
                 res.daily.data.forEach(dayData => {
                     dayStr2dayData[dayData.day] = dayData
-                    dayData.day = luxon.DateTime.fromISO(dayData.day, {zone: usedTimezone})
+                    dayData.day = this.#luxon.DateTime.fromISO(dayData.day, {zone: usedTimezone})
                 })
                 res.daily.getData = day => {
                     day = this.#convertCheckDateTime(day, false)
                     return dayStr2dayData[day.toISO().substr(0, 10)]
                 }
             }
-            if(res.minutely !== null) {
-                let luxon = this.#luxon
+            if(res.minutely !== null && res.minutely !== undefined) {
                 let str2minuteData = {}
                 res.minutely.data.forEach(minuteData => {
                     str2minuteData[minuteData.date] = minuteData
-                    minuteData.date = luxon.DateTime.fromISO(minuteData.date + "Z", {zone: usedTimezone})
+                    minuteData.date = this.#luxon.DateTime.fromISO(minuteData.date + "Z", {zone: usedTimezone})
                 })
                 res.minutely.toString = function() {
                     return "<Minutely data with " + res.minutely.data.length + " timesteps from " +
@@ -197,12 +194,12 @@
                     return str2minuteData[date.setZone("UTC").startOf("minute").toISO().substr(0, 19)]
                 }
             }
-            if(res.current !== null) {
+            if(res.current !== null && res.current !== undefined) {
                 res.current.toString = function() {
                     return "<Current data>"
                 }
             }
-            if(res.alerts !== null) {
+            if(res.alerts !== null && res.alerts !== undefined) {
                 res.alerts.data.forEach(alertData => {
                     alertData.onset = this.#luxon.DateTime.fromISO(alertData.onset + "Z", {zone: usedTimezone})
                     alertData.expires = this.#luxon.DateTime.fromISO(alertData.expires + "Z", {zone: usedTimezone})

--- a/meteosource.js
+++ b/meteosource.js
@@ -327,6 +327,79 @@
             }
             return completeRes
         }
+
+        async getAirQuality(options) {
+            this.#checkInitialized()
+            this.#checkLimitedOptions(options, ["lat", "lon", "placeId", "tz", "lang"])
+            let url = this.#baseUrl + this.#tier + "/air_quality"
+            let args = {lat: options.lat, lon: options.lon, place_id: options.placeId,
+                        timezone: "utc", language: options.lang}
+
+            let res = await this.#httpComposed(url, args)
+
+            let usedTimezone = options.tz ? options.tz : "UTC"
+            let hourStr2hourData = {}
+            res.data.forEach(hourData => {
+                hourStr2hourData[hourData.date] = hourData
+                hourData.date = this.#convertCheckDateTime(hourData.date, true).setZone(usedTimezone)
+            })
+            res.getData = hourDate => {
+                hourDate = this.#convertCheckDateTime(hourDate, false)
+                return hourStr2hourData[hourDate.setZone("UTC").startOf("hour").toISO().substr(0, 19)]
+            }
+            res.toString = function() {
+                return "<AirQuality for lat: " + res.lat + ", lon: " + res.lon + ">"
+            }
+            res.data.toString = function() {
+                return "<AirQuality data with " + res.data.length + " timesteps from " +
+                    res.data[0].date.toISO().substr(0, 19) + " to " + res.data[res.data.length-1].date.toISO().substr(0, 19)
+            }
+            return res
+        }
+
+        async getNearestPlace(options) {
+            this.#checkInitialized()
+            this.#checkLimitedOptions(options, ["lat", "lon", "lang"])
+            let url = this.#baseUrl + this.#tier + "/nearest_place"
+            let args = {lat: options.lat, lon: options.lon, language: options.lang}
+
+            let res = await this.#httpComposed(url, args)
+
+            res.toString = function() {
+                return "<Place " + res.name + " (" + res.place_id + "), " + res.country + ">"
+            }
+            return res
+        }
+
+        async findPlaces(options) {
+            this.#checkInitialized()
+            this.#checkLimitedOptions(options, ["text", "lang"])
+            let url = this.#baseUrl + this.#tier + "/find_places"
+            let args = {text: options.text, language: options.lang}
+
+            return await this.#httpComposedPlaces(url, args)
+        }
+
+        async findPlacesPrefix(options) {
+            this.#checkInitialized()
+            this.#checkLimitedOptions(options, ["text", "lang"])
+            let url = this.#baseUrl + this.#tier + "/find_places_prefix"
+            let args = {text: options.text, language: options.lang}
+
+            return await this.#httpComposedPlaces(url, args)
+        }
+
+        async #httpComposedPlaces(url, args) {
+            let res = await this.#httpComposed(url, args)
+
+            res.forEach(place => {
+                place.toString = function() {
+                    return "<Place " + place.name + " (" + place.place_id + "), " + place.country + ">"
+                }
+            })
+            return res
+        }
+
         #httpComposed(url, args) {
             let argsCleaned = "?key=" + this.#apiKey
             Object.keys(args).forEach(key => {

--- a/meteosource.js
+++ b/meteosource.js
@@ -330,10 +330,12 @@
 
         async getAirQuality(options) {
             this.#checkInitialized()
-            this.#checkLimitedOptions(options, ["lat", "lon", "placeId", "tz", "lang"])
+            this.#checkLimitedOptions(options, ["lat", "lon", "placeId", "tz"])
             let url = this.#baseUrl + this.#tier + "/air_quality"
+            // Note: the air_quality endpoint does not accept a language
+            // parameter (its data is numeric only), unlike the other endpoints.
             let args = {lat: options.lat, lon: options.lon, place_id: options.placeId,
-                        timezone: "utc", language: options.lang}
+                        timezone: "utc"}
 
             let res = await this.#httpComposed(url, args)
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
      "version": "1.0.1",
      "author": "Meteosource <info@meteosource.com> (https://www.meteosource.com)",
      "dependencies": {
-          "luxon": "^2.4.0",
+          "luxon": "^2.4.0"
+     },
+     "devDependencies": {
           "mocha": "^10.0.0"
      },
      "main": "meteosource.js",
      "scripts": {
           "test": "mocha"
      },
-     "files": ["README.md", "index.js", "test.js"]
+     "files": ["meteosource.js", "README.md", "LICENSE"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
      "name": "meteosource",
-     "version": "1.0.1",
+     "version": "1.1.0",
      "author": "Meteosource <info@meteosource.com> (https://www.meteosource.com)",
      "dependencies": {
           "luxon": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
      "version": "1.0.1",
      "author": "Meteosource <info@meteosource.com> (https://www.meteosource.com)",
      "dependencies": {
-          "luxon": "^2.4.0"
+          "luxon": "^3.0.0"
      },
      "devDependencies": {
           "mocha": "^10.0.0"

--- a/test/fixtures/air_quality.json
+++ b/test/fixtures/air_quality.json
@@ -1,0 +1,14 @@
+{
+    "lat": "51.50853N",
+    "lon": "0.12574W",
+    "elevation": 25,
+    "timezone": "UTC",
+    "data": [
+        {"date": "2026-07-28T00:00:00", "aerosol_550": 0.19, "co_surface": 155.5, "no2_surface": 11.2, "ozone_surface": 31.4, "pm10": 14.8, "pm25": 8.9, "so2_surface": 1.6, "air_quality": 2},
+        {"date": "2026-07-28T01:00:00", "aerosol_550": 0.18, "co_surface": 152.3, "no2_surface": 10.7, "ozone_surface": 32.0, "pm10": 14.1, "pm25": 8.5, "so2_surface": 1.5, "air_quality": 2},
+        {"date": "2026-07-28T02:00:00", "aerosol_550": 0.18, "co_surface": 149.8, "no2_surface": 10.1, "ozone_surface": 33.1, "pm10": 13.6, "pm25": 8.2, "so2_surface": 1.5, "air_quality": 2},
+        {"date": "2026-07-28T03:00:00", "aerosol_550": 0.17, "co_surface": 147.2, "no2_surface": 9.6, "ozone_surface": 34.4, "pm10": 13.0, "pm25": 7.8, "so2_surface": 1.4, "air_quality": 1},
+        {"date": "2026-07-28T04:00:00", "aerosol_550": 0.17, "co_surface": 145.9, "no2_surface": 9.2, "ozone_surface": 35.0, "pm10": 12.7, "pm25": 7.6, "so2_surface": 1.4, "air_quality": 1},
+        {"date": "2026-07-28T05:00:00", "aerosol_550": 0.16, "co_surface": 144.6, "no2_surface": 9.0, "ozone_surface": 35.8, "pm10": 12.3, "pm25": 7.4, "so2_surface": 1.4, "air_quality": 1}
+    ]
+}

--- a/test/fixtures/find_places.json
+++ b/test/fixtures/find_places.json
@@ -1,0 +1,57 @@
+[
+    {
+        "name": "London",
+        "place_id": "london",
+        "adm_area1": "England",
+        "adm_area2": "Greater London",
+        "country": "United Kingdom",
+        "lat": "51.50853N",
+        "lon": "0.12574W",
+        "timezone": "Europe/London",
+        "type": "settlement"
+    },
+    {
+        "name": "London",
+        "place_id": "london-6058560",
+        "adm_area1": "Ontario",
+        "adm_area2": null,
+        "country": "Canada",
+        "lat": "42.98339N",
+        "lon": "81.23304W",
+        "timezone": "America/Toronto",
+        "type": "settlement"
+    },
+    {
+        "name": "London",
+        "place_id": "london-4298960",
+        "adm_area1": "Kentucky",
+        "adm_area2": "Laurel",
+        "country": "United States of America",
+        "lat": "37.12898N",
+        "lon": "84.08326W",
+        "timezone": "America/New_York",
+        "type": "settlement"
+    },
+    {
+        "name": "City of London",
+        "place_id": "city-of-london",
+        "adm_area1": "England",
+        "adm_area2": "Greater London",
+        "country": "United Kingdom",
+        "lat": "51.51279N",
+        "lon": "0.09184W",
+        "timezone": "Europe/London",
+        "type": "settlement"
+    },
+    {
+        "name": "London",
+        "place_id": "london-4517009",
+        "adm_area1": "Ohio",
+        "adm_area2": "Madison",
+        "country": "United States of America",
+        "lat": "39.88645N",
+        "lon": "83.44825W",
+        "timezone": "America/New_York",
+        "type": "settlement"
+    }
+]

--- a/test/fixtures/find_places_prefix.json
+++ b/test/fixtures/find_places_prefix.json
@@ -1,0 +1,57 @@
+[
+    {
+        "name": "London",
+        "place_id": "london",
+        "adm_area1": "England",
+        "adm_area2": "Greater London",
+        "country": "United Kingdom",
+        "lat": "51.50853N",
+        "lon": "0.12574W",
+        "timezone": "Europe/London",
+        "type": "settlement"
+    },
+    {
+        "name": "Londrina",
+        "place_id": "londrina",
+        "adm_area1": "Paran\u00e1",
+        "adm_area2": "Londrina",
+        "country": "Brazil",
+        "lat": "23.31028S",
+        "lon": "51.16278W",
+        "timezone": "America/Sao_Paulo",
+        "type": "settlement"
+    },
+    {
+        "name": "London",
+        "place_id": "london-6058560",
+        "adm_area1": "Ontario",
+        "adm_area2": null,
+        "country": "Canada",
+        "lat": "42.98339N",
+        "lon": "81.23304W",
+        "timezone": "America/Toronto",
+        "type": "settlement"
+    },
+    {
+        "name": "Brent",
+        "place_id": "brent",
+        "adm_area1": "England",
+        "adm_area2": "Greater London",
+        "country": "United Kingdom",
+        "lat": "51.55306N",
+        "lon": "0.3023W",
+        "timezone": "Europe/London",
+        "type": "settlement"
+    },
+    {
+        "name": "Bexley",
+        "place_id": "bexley",
+        "adm_area1": "England",
+        "adm_area2": "Greater London",
+        "country": "United Kingdom",
+        "lat": "51.44162N",
+        "lon": "0.14866E",
+        "timezone": "Europe/London",
+        "type": "settlement"
+    }
+]

--- a/test/fixtures/nearest_place.json
+++ b/test/fixtures/nearest_place.json
@@ -1,0 +1,11 @@
+{
+    "name": "London",
+    "place_id": "london",
+    "adm_area1": "England",
+    "adm_area2": "Greater London",
+    "country": "United Kingdom",
+    "lat": "51.50853N",
+    "lon": "0.12574W",
+    "timezone": "Europe/London",
+    "type": "settlement"
+}

--- a/test/fixtures/point.json
+++ b/test/fixtures/point.json
@@ -1,0 +1,142 @@
+{
+    "lat": "51.50853N",
+    "lon": "0.12574W",
+    "elevation": 82,
+    "timezone": "Europe/London",
+    "units": "us",
+    "current": {
+        "icon": "sunny",
+        "icon_num": 2,
+        "summary": "Sunny",
+        "temperature": 76.7,
+        "wind": {
+            "speed": 7.2,
+            "angle": 60,
+            "dir": "ENE"
+        },
+        "precipitation": {
+            "total": 0.0,
+            "type": "none"
+        },
+        "cloud_cover": 0.0
+    },
+    "hourly": {
+        "data": [
+            {
+                "date": "2022-08-12T10:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 76.7,
+                "wind": {
+                    "speed": 7.2,
+                    "dir": "ENE",
+                    "angle": 60
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            },
+            {
+                "date": "2022-08-12T11:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 81.7,
+                "wind": {
+                    "speed": 7.0,
+                    "dir": "ENE",
+                    "angle": 65
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            },
+            {
+                "date": "2022-08-12T12:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 85.7,
+                "wind": {
+                    "speed": 6.9,
+                    "dir": "ENE",
+                    "angle": 69
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            },
+            {
+                "date": "2022-08-12T13:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 88.4,
+                "wind": {
+                    "speed": 7.4,
+                    "dir": "ENE",
+                    "angle": 78
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            },
+            {
+                "date": "2022-08-12T14:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 89.8,
+                "wind": {
+                    "speed": 9.2,
+                    "dir": "E",
+                    "angle": 94
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            },
+            {
+                "date": "2022-08-12T15:00:00",
+                "weather": "sunny",
+                "icon": 2,
+                "summary": "Sunny",
+                "temperature": 89.8,
+                "wind": {
+                    "speed": 10.4,
+                    "dir": "E",
+                    "angle": 101
+                },
+                "cloud_cover": {
+                    "total": 0.0
+                },
+                "precipitation": {
+                    "total": 0.0,
+                    "type": "none"
+                }
+            }
+        ]
+    },
+    "daily": null
+}

--- a/test/fixtures/point_all.json
+++ b/test/fixtures/point_all.json
@@ -1,0 +1,64 @@
+{
+    "lat": "50.088N",
+    "lon": "14.42076E",
+    "elevation": 202,
+    "timezone": "UTC",
+    "units": "metric",
+    "current": {
+        "icon": "sunny",
+        "icon_num": 2,
+        "summary": "Sunny",
+        "temperature": 24.5,
+        "wind": {"speed": 2.1, "angle": 300, "dir": "WNW"},
+        "precipitation": {"total": 0.0, "type": "none"},
+        "cloud_cover": 5
+    },
+    "hourly": {
+        "data": [
+            {"date": "2022-08-12T10:00:00", "weather": "sunny", "icon": 2, "summary": "Sunny", "temperature": 24.5, "wind": {"speed": 2.1, "dir": "WNW", "angle": 300}},
+            {"date": "2022-08-12T11:00:00", "weather": "sunny", "icon": 2, "summary": "Sunny", "temperature": 25.6, "wind": {"speed": 2.4, "dir": "WNW", "angle": 295}},
+            {"date": "2022-08-12T12:00:00", "weather": "partly_sunny", "icon": 4, "summary": "Partly sunny", "temperature": 26.4, "wind": {"speed": 2.8, "dir": "W", "angle": 280}},
+            {"date": "2022-08-12T13:00:00", "weather": "partly_sunny", "icon": 4, "summary": "Partly sunny", "temperature": 27.0, "wind": {"speed": 3.0, "dir": "W", "angle": 275}}
+        ]
+    },
+    "daily": {
+        "data": [
+            {"day": "2022-08-12", "weather": "sunny", "icon": 2, "summary": "Sunny, more clouds in the evening.", "all_day": {"temperature": 25.1, "temperature_min": 15.2, "temperature_max": 27.4}},
+            {"day": "2022-08-13", "weather": "partly_sunny", "icon": 4, "summary": "Partly sunny, fewer clouds in the afternoon.", "all_day": {"temperature": 24.0, "temperature_min": 14.8, "temperature_max": 26.9}},
+            {"day": "2022-08-14", "weather": "cloudy", "icon": 7, "summary": "Cloudy, light rain in the evening.", "all_day": {"temperature": 21.3, "temperature_min": 14.1, "temperature_max": 24.2}}
+        ]
+    },
+    "minutely": {
+        "summary": "No precipitation until the end of the forecast period.",
+        "data": [
+            {"date": "2022-08-12T10:00:00", "precipitation": 0.0},
+            {"date": "2022-08-12T10:01:00", "precipitation": 0.0},
+            {"date": "2022-08-12T10:02:00", "precipitation": 0.0},
+            {"date": "2022-08-12T10:03:00", "precipitation": 0.0}
+        ]
+    },
+    "alerts": {
+        "data": [
+            {
+                "event": "Heat warning",
+                "onset": "2022-08-12T08:00:00",
+                "expires": "2022-08-12T20:00:00",
+                "sender": "Test weather service",
+                "certainty": "Likely",
+                "severity": "Moderate",
+                "headline": "Heat warning issued for the area",
+                "description": "High temperatures expected."
+            },
+            {
+                "event": "Thunderstorm watch",
+                "onset": "2022-08-13T00:00:00",
+                "expires": "2022-08-13T12:00:00",
+                "sender": "Test weather service",
+                "certainty": "Possible",
+                "severity": "Severe",
+                "headline": "Thunderstorms possible overnight",
+                "description": "Scattered thunderstorms may develop."
+            }
+        ]
+    }
+}

--- a/test/fixtures/time_machine.json
+++ b/test/fixtures/time_machine.json
@@ -1,0 +1,297 @@
+{
+    "lat": "51.50853N",
+    "lon": "0.12574W",
+    "elevation": 25,
+    "timezone": "UTC",
+    "units": "metric",
+    "data": [
+        {
+            "date": "2015-09-07T00:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 10.6,
+            "wind": {
+                "speed": 3.0,
+                "gusts": 5.4,
+                "angle": 327,
+                "dir": "NNW"
+            }
+        },
+        {
+            "date": "2015-09-07T01:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 10.0,
+            "wind": {
+                "speed": 2.7,
+                "gusts": 4.9,
+                "angle": 323,
+                "dir": "NW"
+            }
+        },
+        {
+            "date": "2015-09-07T02:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 9.3,
+            "wind": {
+                "speed": 2.6,
+                "gusts": 4.5,
+                "angle": 318,
+                "dir": "NW"
+            }
+        },
+        {
+            "date": "2015-09-07T03:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 8.8,
+            "wind": {
+                "speed": 2.5,
+                "gusts": 4.2,
+                "angle": 319,
+                "dir": "NW"
+            }
+        },
+        {
+            "date": "2015-09-07T04:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 8.5,
+            "wind": {
+                "speed": 2.5,
+                "gusts": 4.1,
+                "angle": 319,
+                "dir": "NW"
+            }
+        },
+        {
+            "date": "2015-09-07T05:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 8.0,
+            "wind": {
+                "speed": 2.5,
+                "gusts": 4.1,
+                "angle": 323,
+                "dir": "NW"
+            }
+        },
+        {
+            "date": "2015-09-07T06:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 8.2,
+            "wind": {
+                "speed": 2.7,
+                "gusts": 5.2,
+                "angle": 331,
+                "dir": "NNW"
+            }
+        },
+        {
+            "date": "2015-09-07T07:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 9.8,
+            "wind": {
+                "speed": 2.7,
+                "gusts": 6.1,
+                "angle": 338,
+                "dir": "NNW"
+            }
+        },
+        {
+            "date": "2015-09-07T08:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 12.0,
+            "wind": {
+                "speed": 2.7,
+                "gusts": 6.5,
+                "angle": 353,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T09:00:00",
+            "weather": "sunny",
+            "icon": 2,
+            "temperature": 14.2,
+            "wind": {
+                "speed": 2.9,
+                "gusts": 7.2,
+                "angle": 5,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T10:00:00",
+            "weather": "partly_sunny",
+            "icon": 4,
+            "temperature": 15.9,
+            "wind": {
+                "speed": 3.4,
+                "gusts": 8.8,
+                "angle": 12,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T11:00:00",
+            "weather": "mostly_cloudy",
+            "icon": 5,
+            "temperature": 16.9,
+            "wind": {
+                "speed": 4.0,
+                "gusts": 9.2,
+                "angle": 1,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T12:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 17.5,
+            "wind": {
+                "speed": 4.4,
+                "gusts": 9.3,
+                "angle": 1,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T13:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 17.3,
+            "wind": {
+                "speed": 4.6,
+                "gusts": 9.1,
+                "angle": 5,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T14:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 17.1,
+            "wind": {
+                "speed": 4.4,
+                "gusts": 8.9,
+                "angle": 9,
+                "dir": "N"
+            }
+        },
+        {
+            "date": "2015-09-07T15:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 16.7,
+            "wind": {
+                "speed": 4.2,
+                "gusts": 8.1,
+                "angle": 12,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T16:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 16.3,
+            "wind": {
+                "speed": 3.8,
+                "gusts": 8.0,
+                "angle": 14,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T17:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 15.9,
+            "wind": {
+                "speed": 3.5,
+                "gusts": 6.8,
+                "angle": 18,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T18:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 15.4,
+            "wind": {
+                "speed": 2.8,
+                "gusts": 5.1,
+                "angle": 21,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T19:00:00",
+            "weather": "overcast",
+            "icon": 7,
+            "temperature": 14.5,
+            "wind": {
+                "speed": 2.6,
+                "gusts": 5.0,
+                "angle": 21,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T20:00:00",
+            "weather": "mostly_cloudy",
+            "icon": 5,
+            "temperature": 13.0,
+            "wind": {
+                "speed": 2.6,
+                "gusts": 4.9,
+                "angle": 21,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T21:00:00",
+            "weather": "mostly_cloudy",
+            "icon": 5,
+            "temperature": 12.4,
+            "wind": {
+                "speed": 2.6,
+                "gusts": 4.4,
+                "angle": 22,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T22:00:00",
+            "weather": "mostly_cloudy",
+            "icon": 5,
+            "temperature": 11.3,
+            "wind": {
+                "speed": 2.3,
+                "gusts": 4.3,
+                "angle": 26,
+                "dir": "NNE"
+            }
+        },
+        {
+            "date": "2015-09-07T23:00:00",
+            "weather": "partly_sunny",
+            "icon": 4,
+            "temperature": 10.5,
+            "wind": {
+                "speed": 2.3,
+                "gusts": 3.7,
+                "angle": 33,
+                "dir": "NNE"
+            }
+        }
+    ]
+}

--- a/test/live.test.js
+++ b/test/live.test.js
@@ -1,13 +1,13 @@
 var assert = require('assert')
 var luxon = require('luxon')
-var meteosource = require(".")
+var meteosource = require("..")
 
-if(process.env.API_KEY)
-    var apiKey = process.env.API_KEY
-else
-    throw new Error("ENV variable API_KEY must be set")
+// These tests exercise the live API and require the API_KEY env variable
+// (a flexi tier key); without it the whole suite is skipped.
+var apiKey = process.env.API_KEY
+var describeLive = apiKey ? describe : describe.skip
 
-describe('meteosource.Meteosource', function () {
+describeLive('meteosource live API', function () {
     this.timeout(5000)
     describe('#getPointForecast', function () {
         it('completes', function (done) {
@@ -92,6 +92,35 @@ describe('meteosource.Meteosource', function () {
             let m = new meteosource.Meteosource(apiKey, "flexi")
             let q = await m.getTimeMachine({placeId: "prague", dateFrom: "2022-03-03", dateTo: "2022-03-05"})
             assert.equal(+q.getData("2022-03-03T00:00:00Z").date, +q.data[0].date)
+        })
+    })
+    describe('#getAirQuality', function () {
+        it('completes and converts the dates', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getAirQuality({placeId: "london"})
+            assert.ok(q.data.length > 0)
+            assert.ok(q.data.every(h => luxon.DateTime.isDateTime(h.date)))
+        })
+    })
+    describe('#getNearestPlace', function () {
+        it('finds london', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let place = await m.getNearestPlace({lat: 51.50853, lon: -0.1257})
+            assert.equal(place.place_id, "london")
+        })
+    })
+    describe('#findPlaces', function () {
+        it('finds london', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let places = await m.findPlaces({text: "london"})
+            assert.ok(places.some(p => p.place_id === "london"))
+        })
+    })
+    describe('#findPlacesPrefix', function () {
+        it('finds london by prefix', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let places = await m.findPlacesPrefix({text: "lond"})
+            assert.ok(places.some(p => p.place_id === "london"))
         })
     })
 });

--- a/test/offline.test.js
+++ b/test/offline.test.js
@@ -188,12 +188,12 @@ describe('meteosource offline', function () {
     describe('#getAirQuality', function () {
         it('composes the request URL from the options', async function () {
             let m = new meteosource.Meteosource(apiKey, "flexi")
-            await m.getAirQuality({placeId: "london", lang: "en"})
+            await m.getAirQuality({placeId: "london"})
             let url = requestedUrls[0]
             assert.equal(url.pathname, "/api/v1/flexi/air_quality")
             assert.equal(url.searchParams.get("key"), apiKey)
             assert.equal(url.searchParams.get("place_id"), "london")
-            assert.equal(url.searchParams.get("language"), "en")
+            assert.equal(url.searchParams.has("language"), false)
             assert.equal(url.searchParams.get("timezone"), "utc")
         })
         it('accepts lat+lon instead of placeId', async function () {

--- a/test/offline.test.js
+++ b/test/offline.test.js
@@ -1,0 +1,276 @@
+var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
+var luxon = require('luxon')
+var meteosource = require("..")
+
+var apiKey = "test-api-key"
+
+function loadFixture(name) {
+    // parses a fresh copy on every call, because the library mutates the response
+    return JSON.parse(fs.readFileSync(path.join(__dirname, "fixtures", name + ".json")))
+}
+
+// The library resolves the global fetch() at call time, so replacing global.fetch
+// routes all its requests to local fixtures without any network access or API key.
+var realFetch = global.fetch
+var requestedUrls = []
+
+function installFakeFetch(fixtureByEndpoint) {
+    requestedUrls = []
+    global.fetch = async function (urlStr) {
+        let url = new URL(urlStr)
+        requestedUrls.push(url)
+        let endpoint = url.pathname.split("/").pop()
+        let spec = fixtureByEndpoint ? fixtureByEndpoint[endpoint] : undefined
+        if(typeof spec === "function")
+            return spec(url)
+        let body = loadFixture(spec ? spec : endpoint)
+        if(endpoint === "time_machine") {
+            // reuse the single-day fixture for whatever date was requested
+            let date = url.searchParams.get("date")
+            body.data.forEach(item => item.date = date + item.date.substr(10))
+        }
+        return {status: 200, json: async () => body}
+    }
+}
+
+describe('meteosource offline', function () {
+    beforeEach(function () {
+        installFakeFetch()
+    })
+    afterEach(function () {
+        global.fetch = realFetch
+    })
+
+    describe('constructor', function () {
+        it('rejects a non-string API key', function () {
+            assert.throws(() => new meteosource.Meteosource(42, "flexi"), e => e.code === -1)
+        })
+        it('rejects an empty API key', function () {
+            assert.throws(() => new meteosource.Meteosource("", "flexi"), e => e.code === -1)
+        })
+        it('rejects an unknown tier', function () {
+            assert.throws(() => new meteosource.Meteosource(apiKey, "gold"), e => e.code === -1)
+        })
+    })
+
+    describe('#getPointForecast', function () {
+        it('composes the request URL from the options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await m.getPointForecast({placeId: "prague", sections: ["current", "hourly"], lang: "en"})
+            assert.equal(requestedUrls.length, 1)
+            let url = requestedUrls[0]
+            assert.equal(url.pathname, "/api/v1/flexi/point")
+            assert.equal(url.searchParams.get("key"), apiKey)
+            assert.equal(url.searchParams.get("place_id"), "prague")
+            assert.equal(url.searchParams.get("sections"), "current,hourly")
+            assert.equal(url.searchParams.get("language"), "en")
+            assert.equal(url.searchParams.get("timezone"), "utc")
+        })
+        it('rejects unknown options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getPointForecast({placeId: "prague", foo: 1}), e => e.code === -1)
+        })
+        it('converts hourly dates to luxon.DateTime in UTC by default', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague"})
+            assert.ok(p.hourly.data.every(h => luxon.DateTime.isDateTime(h.date)))
+            assert.ok(p.hourly.data.every(h => h.date.zoneName === "UTC"))
+        })
+        it('converts dates to the requested timezone', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague", tz: "Europe/Prague"})
+            assert.equal(p.hourly.data[0].date.zoneName, "Europe/Prague")
+            // the instant must stay the same, only the zone changes
+            assert.equal(+p.hourly.data[0].date, +luxon.DateTime.fromISO("2022-08-12T10:00:00Z"))
+        })
+        it('tolerates sections that are null or missing entirely', async function () {
+            // the point fixture has daily: null and no minutely/alerts keys at all
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague"})
+            assert.equal(p.daily, null)
+            assert.equal(p.minutely, undefined)
+            assert.equal(p.alerts, undefined)
+        })
+        it('can look up an hour by ISO string or luxon.DateTime', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague"})
+            assert.equal(+p.hourly.getData("2022-08-12T11:00:00Z").date, +p.hourly.data[1].date)
+            assert.equal(+p.hourly.getData(luxon.DateTime.fromISO("2022-08-12T11:30:00Z")).date, +p.hourly.data[1].date)
+        })
+        it('converts daily, minutely and alerts sections when present', async function () {
+            installFakeFetch({point: "point_all"})
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague", sections: "all"})
+            assert.ok(luxon.DateTime.isDateTime(p.daily.data[0].day))
+            assert.ok(luxon.DateTime.isDateTime(p.minutely.data[0].date))
+            assert.ok(p.alerts.data.every(a => luxon.DateTime.isDateTime(a.onset) && luxon.DateTime.isDateTime(a.expires)))
+            assert.equal(p.daily.getData("2022-08-13").day.toISO().substr(0, 10), "2022-08-13")
+            assert.equal(+p.minutely.getData("2022-08-12T10:02:30Z").date, +p.minutely.data[2].date)
+        })
+        it('finds active alerts for a given time', async function () {
+            installFakeFetch({point: "point_all"})
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let p = await m.getPointForecast({placeId: "prague", sections: "all"})
+            let active = p.alerts.getActiveAlerts(luxon.DateTime.fromISO("2022-08-12T12:00:00Z"))
+            assert.equal(active.length, 1)
+            assert.equal(active[0].event, "Heat warning")
+            assert.equal(p.alerts.getActiveAlerts(luxon.DateTime.fromISO("2022-08-20T00:00:00Z")).length, 0)
+        })
+        it('throws a MeteosourceError with the status code on an API error', async function () {
+            installFakeFetch({point: () => ({status: 402, json: async () => ({detail: "Payment required"})})})
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getPointForecast({placeId: "prague"}),
+                e => e.code === 402 && e.detail === "Payment required")
+        })
+    })
+
+    describe('#getTimeMachine', function () {
+        it('completes for a single date', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", date: "2022-03-03"})
+            assert.equal(q.data.length, 24)
+            assert.equal(requestedUrls[0].pathname, "/api/v1/flexi/time_machine")
+            assert.equal(requestedUrls[0].searchParams.get("date"), "2022-03-03")
+        })
+        it('makes one request per day for a range of dates', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", dateFrom: "2022-03-03", dateTo: "2022-03-05"})
+            assert.equal(q.data.length, 3*24)
+            assert.equal(requestedUrls.length, 3)
+            assert.deepEqual(requestedUrls.map(u => u.searchParams.get("date")),
+                ["2022-03-03", "2022-03-04", "2022-03-05"])
+        })
+        it('completes for an array of dates', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", date: ["2022-03-03", "2022-03-04"]})
+            assert.equal(q.data.length, 2*24)
+        })
+        it('converts all dates to luxon.DateTime in UTC', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", date: "2022-03-03"})
+            assert.ok(q.data.every(h => luxon.DateTime.isDateTime(h.date)))
+            assert.ok(q.data.every(h => h.date.zoneName === "UTC"))
+        })
+        it('can use the function to search in the data', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", date: "2022-03-03", tz: "Europe/Prague"})
+            assert.equal(+q.getData("2022-03-03T00:00:00Z").date, +q.data[0].date)
+        })
+        it('requires either date or dateFrom+dateTo', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getTimeMachine({placeId: "prague"}), e => e.code === -1)
+            await assert.rejects(m.getTimeMachine({placeId: "prague", date: "2022-03-03", dateFrom: "2022-03-01"}),
+                e => e.code === -1)
+        })
+        it('rejects dateFrom greater than dateTo', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getTimeMachine({placeId: "prague", dateFrom: "2022-03-05", dateTo: "2022-03-03"}),
+                e => e.code === -1)
+        })
+        it('collects failed dates when strictMode is off', async function () {
+            installFakeFetch({time_machine: url => {
+                let date = url.searchParams.get("date")
+                if(date === "2022-03-04")
+                    return {status: 500, json: async () => ({detail: "Server error"})}
+                let body = loadFixture("time_machine")
+                body.data.forEach(item => item.date = date + item.date.substr(10))
+                return {status: 200, json: async () => body}
+            }})
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getTimeMachine({placeId: "prague", dateFrom: "2022-03-03", dateTo: "2022-03-05", strictMode: false})
+            assert.equal(q.data.length, 2*24)
+            assert.deepEqual(q.failedDates, ["2022-03-04"])
+        })
+    })
+
+    describe('#getAirQuality', function () {
+        it('composes the request URL from the options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await m.getAirQuality({placeId: "london", lang: "en"})
+            let url = requestedUrls[0]
+            assert.equal(url.pathname, "/api/v1/flexi/air_quality")
+            assert.equal(url.searchParams.get("key"), apiKey)
+            assert.equal(url.searchParams.get("place_id"), "london")
+            assert.equal(url.searchParams.get("language"), "en")
+            assert.equal(url.searchParams.get("timezone"), "utc")
+        })
+        it('accepts lat+lon instead of placeId', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await m.getAirQuality({lat: 51.50853, lon: -0.12574})
+            assert.equal(requestedUrls[0].searchParams.get("lat"), "51.50853")
+            assert.equal(requestedUrls[0].searchParams.get("lon"), "-0.12574")
+        })
+        it('converts all dates to luxon.DateTime in UTC by default', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getAirQuality({placeId: "london"})
+            assert.ok(q.data.every(h => luxon.DateTime.isDateTime(h.date)))
+            assert.ok(q.data.every(h => h.date.zoneName === "UTC"))
+        })
+        it('converts dates to the requested timezone', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getAirQuality({placeId: "london", tz: "Europe/London"})
+            assert.ok(q.data.every(h => h.date.zoneName === "Europe/London"))
+        })
+        it('can use the function to search in the data', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let q = await m.getAirQuality({placeId: "london"})
+            assert.equal(q.getData("2026-07-28T02:00:00Z").air_quality, q.data[2].air_quality)
+            assert.equal(+q.getData(luxon.DateTime.fromISO("2026-07-28T02:30:00Z")).date, +q.data[2].date)
+        })
+        it('rejects unknown options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getAirQuality({placeId: "london", units: "us"}), e => e.code === -1)
+        })
+    })
+
+    describe('#getNearestPlace', function () {
+        it('returns the place for given coordinates', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let place = await m.getNearestPlace({lat: 51.50853, lon: -0.1257, lang: "en"})
+            let url = requestedUrls[0]
+            assert.equal(url.pathname, "/api/v1/flexi/nearest_place")
+            assert.equal(url.searchParams.get("lat"), "51.50853")
+            assert.equal(url.searchParams.get("lon"), "-0.1257")
+            assert.equal(url.searchParams.get("language"), "en")
+            assert.equal(place.place_id, "london")
+            assert.equal(place.toString(), "<Place London (london), United Kingdom>")
+        })
+        it('rejects unknown options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.getNearestPlace({placeId: "london"}), e => e.code === -1)
+        })
+    })
+
+    describe('#findPlaces', function () {
+        it('returns the list of matching places', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let places = await m.findPlaces({text: "london", lang: "en"})
+            let url = requestedUrls[0]
+            assert.equal(url.pathname, "/api/v1/flexi/find_places")
+            assert.equal(url.searchParams.get("text"), "london")
+            assert.equal(url.searchParams.get("language"), "en")
+            assert.ok(Array.isArray(places))
+            assert.ok(places.length > 0)
+            assert.equal(places[0].place_id, "london")
+            assert.equal(places[0].toString(), "<Place London (london), United Kingdom>")
+        })
+        it('rejects unknown options', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            await assert.rejects(m.findPlaces({placeId: "london"}), e => e.code === -1)
+        })
+    })
+
+    describe('#findPlacesPrefix', function () {
+        it('returns the list of matching places', async function () {
+            let m = new meteosource.Meteosource(apiKey, "flexi")
+            let places = await m.findPlacesPrefix({text: "lond"})
+            let url = requestedUrls[0]
+            assert.equal(url.pathname, "/api/v1/flexi/find_places_prefix")
+            assert.equal(url.searchParams.get("text"), "lond")
+            assert.ok(Array.isArray(places))
+            assert.ok(places.every(p => p.place_id))
+        })
+    })
+});


### PR DESCRIPTION
Update to match current Meteosource API and add missing endpoints.

  - Add places search / prefix search / nearest-place endpoints
  - Add air quality endpoint
  - Fix: air_quality request was rejected by the API (it doesn't accept a
    `language` param, unlike other endpoints) — removed from method signature
  - Add CI workflow (GitHub Actions)
  - Make test suite runnable offline (mocked responses), keep live tests optional
  - Update README with new usage examples
  - Verified manually against the live API with a real Flexi-tier key